### PR TITLE
Rundeck 3 compat

### DIFF
--- a/rundeck/files/rundeck-config.properties.jinja
+++ b/rundeck/files/rundeck-config.properties.jinja
@@ -19,6 +19,7 @@ dataSource.password={{ rundeck_settings.config.datasource.password }}
 {%- else %}
 dataSource.dbCreate = update
 dataSource.url = jdbc:h2:file:/var/lib/rundeck/data/rundeckdb;MVCC=true
+rundeck.log4j.config.file = {{ rundeck_settings.log4j_path }}
 {%- endif %}
 {%- if 'extra_opts' in rundeck_settings.config %}
 {%- for opt,value in rundeck_settings.config.extra_opts.items() %}

--- a/rundeck/map.jinja
+++ b/rundeck/map.jinja
@@ -14,12 +14,22 @@
         'rundeckd_path': '/etc/default/rundeckd',
         'login_path': '/etc/rundeck/jaas-loginmodule.conf',
         'pkg_java': salt['grains.filter_by']({
-            '14': 'openjdk-7-jdk',
-            '16': 'openjdk-8-jdk',
-        }, grain='osmajorrelease'),
+            'Ubuntu': salt['grains.filter_by']({
+                '14': 'openjdk-7-jdk',
+                '16': 'openjdk-8-jdk',
+                '18': 'openjdk-8-jdk',
+                'default': 'openjdk-8-jdk',
+            }, grain='osmajorrelease'),
+            'Debian': salt['grains.filter_by']({
+                '9': 'openjdk-8-jdk',
+                'default': 'openjdk-8-jdk',
+            }, grain='osmajorrelease'),
+            'default': 'openjdk-8-jdk',
+        }, grain='os'),
         'user': 'rundeck',
         'group': 'rundeck',
         'plugins_path': '/var/lib/rundeck/libext/',
+        'log4j_path': '/etc/rundeck/log4j.properties',
     },
     'RedHat': {
         'repo_url': 'http://repo.rundeck.org/latest.rpm',
@@ -35,6 +45,7 @@
         'user': 'rundeck',
         'group': 'rundeck',
         'plugins_path': '/var/lib/rundeck/libext',
+        'log4j_path': '/etc/rundeck/log4j.properties',
     },
 }, merge=salt['pillar.get']('rundeck:lookup')) %}
 


### PR DESCRIPTION
quickwin to :
 - get formula run successfully on Debian9
-  get rundeck > 3 service working
-> https://github.com/rundeck/rundeck/blob/v3.0.0/RELEASE.md

Note:
  openjdk-11-jre isn't yet supported due to : https://github.com/rundeck/rundeck/issues/3413